### PR TITLE
fixed variable name

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2893,7 +2893,7 @@ after which the expression itself can be evaluated.
 
    for (auto& var_name : variable_list)
    {
-      T& v = symbol_table.variable_ref(var_name);
+      T& v = unknown_var_symbol_table.variable_ref(var_name);
 
       v = ...;
    }


### PR DESCRIPTION
[Section 18: Unknown Unkowns] 
In my test, the reference of an unknown unknown could only be obtained from unknown_var_symbol_table, not from symbol_table.